### PR TITLE
Add README and MIT license

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2024 Scenarium contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,1 +1,27 @@
 # Scenarium
+
+Scenarium is a collection of tools and libraries for building node based applications.  
+The core graph and utilities are written in Rust and exposed through various front end implementations.
+
+## Repository Layout
+
+- **common** – shared utilities used across the workspace
+- **graph** – the main graph library
+- **cs_interop** – Rust FFI bindings consumed by the .NET editor
+- **ScenariumEditor.NET** – Windows editor built with WPF
+- **ScenariumEditor.QML** – Qt Quick (C++) editor
+
+## Building
+
+This repository is organised as a Rust workspace.  The native tools require a recent Rust toolchain and, for the QML editor, a Qt6 installation.
+
+```bash
+# build all Rust crates
+cargo build --workspace
+```
+
+Each front end can be built using its respective build system.  The .NET editor requires the .NET SDK, while the QML editor uses CMake with Qt6.
+
+## License
+
+This project is licensed under the terms of the MIT license.  See [LICENSE](LICENSE) for more information.


### PR DESCRIPTION
## Summary
- add project README with build overview
- add MIT LICENSE

## Testing
- `cargo build --verbose --no-default-features --workspace --all` *(fails: Could not connect to crates.io)*
- `cargo test --verbose --no-default-features -p graph` *(fails: Could not connect to crates.io)*
- `cargo test --verbose --no-default-features -p common` *(fails: Could not connect to crates.io)*