### PR TITLE
Fix FfiUuid to String conversion

### DIFF
--- a/cs_interop/src/utils.rs
+++ b/cs_interop/src/utils.rs
@@ -31,7 +31,7 @@ impl TryFrom<String> for FfiUuid {
 
 impl From<FfiUuid> for String {
     fn from(ffi_uuid: FfiUuid) -> Self {
-        ffi_uuid.into()
+        uuid::Uuid::from(ffi_uuid).to_string()
     }
 }
 


### PR DESCRIPTION
## Summary
- implement proper conversion from `FfiUuid` to `String`
- ensure utils file ends with a newline

## Testing
- `cargo check` *(fails: failed to download crates)*